### PR TITLE
#fix correct calculation of the center of cuboid_hull

### DIFF
--- a/excitation/optimizer.py
+++ b/excitation/optimizer.py
@@ -275,16 +275,16 @@ class Optimizer(object):
 
         b = np.array(self.link_cuboid_hulls[l0_name][0]) * s0
         p = np.array(self.link_cuboid_hulls[l0_name][1])
-        b0_center = 0.5*np.array([np.abs(b[1][0])-np.abs(b[0][0]) + p[0],
-                                  np.abs(b[1][1])-np.abs(b[0][1]) + p[1],
-                                  np.abs(b[1][2])-np.abs(b[0][2]) + p[2]])
+        b0_center = 0.5*np.array([(b[1][0])+(b[0][0]) + p[0],
+                                  (b[1][1])+(b[0][1]) + p[1],
+                                  (b[1][2])+(b[0][2]) + p[2]])
         b0 = fcl.Box(b[1][0]-b[0][0], b[1][1]-b[0][1], b[1][2]-b[0][2])
 
         b = np.array(self.link_cuboid_hulls[l1_name][0]) * s1
         p = np.array(self.link_cuboid_hulls[l1_name][1])
-        b1_center = 0.5*np.array([np.abs(b[1][0])-np.abs(b[0][0]) + p[0],
-                                  np.abs(b[1][1])-np.abs(b[0][1]) + p[1],
-                                  np.abs(b[1][2])-np.abs(b[0][2]) + p[2]])
+        b1_center = 0.5*np.array([(b[1][0])+(b[0][0]) + p[0],
+                                  (b[1][1])+(b[0][1]) + p[1],
+                                  (b[1][2])+(b[0][2]) + p[2]])
         b1 = fcl.Box(b[1][0]-b[0][0], b[1][1]-b[0][1], b[1][2]-b[0][2])
 
         # move box to pos + box center pos (model has pos in link origin, box has zero at center)

--- a/visualizer.py
+++ b/visualizer.py
@@ -784,9 +784,9 @@ class Visualizer(object):
                     b = np.array(boxes[n_name][0]) * self.config['scaleCollisionHull']
                     p = np.array(boxes[n_name][1])
                     body['size3'] = np.array([b[1][0]-b[0][0], b[1][1]-b[0][1], b[1][2]-b[0][2]])
-                    body['center'] = 0.5*np.array([np.abs(b[1][0])-np.abs(b[0][0]) + p[0],
-                                                   np.abs(b[1][1])-np.abs(b[0][1]) + p[1],
-                                                   np.abs(b[1][2])-np.abs(b[0][2])] + p[2])
+                    body['center'] = 0.5*np.array([(b[1][0])+(b[0][0]) + p[0],
+                                                   (b[1][1])+(b[0][1]) + p[1],
+                                                   (b[1][2])+(b[0][2])] + p[2])
                 except KeyError:
                     print('using cube for {}'.format(n_name))
                     body['size3'] = np.array([0.1, 0.1, 0.1])


### PR DESCRIPTION
When the corner points of link_cuboid_hulls have the same sign, this error will occur.

Visual model;
![image](https://user-images.githubusercontent.com/5611562/51817261-efb57a00-2304-11e9-8ef8-9f5b15352810.png)

raw code collision model :

![image](https://user-images.githubusercontent.com/5611562/51817304-1b386480-2305-11e9-8b7d-4a14bab77861.png)

modified code collision model:

![image](https://user-images.githubusercontent.com/5611562/51817327-31462500-2305-11e9-9a62-01e496da4f04.png)




