### PR TITLE
Geometric (log-det divergence) CAD regularization prior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.9.8
+
+Standard-parameter identification quality: better CAD null-space priors and friction
+modeling. See `documentation/std_parameter_roadmap.md` for the overarching design notes.
+
+### Identification — CAD null-space priors
+- `cadRegularizationMode: geometric`: pull each link's pseudo-inertia toward the a priori
+  (CAD) model with the log-det Bregman divergence on the SPD manifold \[Lee2020\] instead of
+  a Euclidean distance. The divergence is coordinate/frame invariant and diverges as a link
+  approaches degeneracy, so it actively repels the zero-mass / flat-inertia null-space
+  solutions a Euclidean pull leaves unpenalized. Evaluated in whitened (affine-invariant)
+  form `tr(Q) − logdet(Q) − 4` with `Q = P₀^{-1/2} P P₀^{-1/2}` for numerical stability,
+  and the torque-residual block is normalized so the conic problem stays well-scaled on
+  large floating-base models. Strength is `geometricRegularizationFactor`;
+  `geometricObservabilityWeighting` optionally scales each link's divergence by its
+  observability weight (helps only with heterogeneous per-link CAD trust). Opt-in; pinned
+  (`dontChangeLinks`) and degenerate-CAD links are skipped. See
+  `documentation/geometric_prior_analysis.md`.
+- `cadRegularizationMode: observability`: pull each standard parameter toward the a priori
+  (CAD) model with a per-parameter weight that grows where the data determines it poorly
+  (vs. the previous hard identifiable/non-identifiable split). Keeps the standard-parameter
+  decomposition closer to CAD in weakly-excited directions. On a well-conditioned model
+  (walkman) this barely affects the torque fit; on small/poorly-conditioned systems it can
+  shift it more, so it is opt-in and the default remains `uniform`.
+
+### Identification — friction and data weighting
+- Two-step friction identification: the smoothed Coulomb sign term is centralized in
+  `helpers.getFrictionSignSeries` (shared by the regressor columns, the friction OLS and
+  all torque predictions) and computed from the raw measured velocities low-pass filtered
+  at `frictionVelocityCutoff` to suppress sign chatter near zero velocity.
+- `frictionVelocityDeadZone`: Swevers-style velocity dead zone in the friction OLS that
+  keeps the Coulomb and viscous terms separable under velocity noise.
+- `frictionFvRegularization`: per-joint Tikhonov prior pulling the viscous coefficient
+  toward the a priori URDF value (the OLS was previously unregularized).
+- `useTrajectoryWeighting`: with several measurement files (already supported via repeated
+  `--measurements`), weight each file's base-wrench equations by the inverse of its
+  residual noise rather than stacking samples equally, so a noisier file does not dominate.
+- The identifier reports friction parameter errors against the real model when
+  `--model_real` is given.
+
 ## 0.9.7
 
 ### Optimization (pyOptSparse -> cyipopt)
@@ -41,27 +81,6 @@
   under-approximate protruding parts and `scaleCollisionHull` shrinks them).
 - The visualizer marks robot-vs-world clearance violations (previously only robot
   self-collisions), using the same margin semantics as the optimizer.
-
-### Identification
-- `cadRegularizationMode: observability`: pull each standard parameter toward the a priori
-  (CAD) model with a per-parameter weight that grows where the data determines it poorly
-  (vs. the previous hard identifiable/non-identifiable split). Keeps the standard-parameter
-  decomposition closer to CAD in weakly-excited directions. On a well-conditioned model
-  (walkman) this barely affects the torque fit; on small/poorly-conditioned systems it can
-  shift it more, so it is opt-in and the default remains `uniform`.
-- Two-step friction identification: the smoothed Coulomb sign term is centralized in
-  `helpers.getFrictionSignSeries` (shared by the regressor columns, the friction OLS and
-  all torque predictions) and computed from the raw measured velocities low-pass filtered
-  at `frictionVelocityCutoff` to suppress sign chatter near zero velocity.
-- `frictionVelocityDeadZone`: Swevers-style velocity dead zone in the friction OLS that
-  keeps the Coulomb and viscous terms separable under velocity noise.
-- `frictionFvRegularization`: per-joint Tikhonov prior pulling the viscous coefficient
-  toward the a priori URDF value (the OLS was previously unregularized).
-- `useTrajectoryWeighting`: with several measurement files (already supported via repeated
-  `--measurements`), weight each file's base-wrench equations by the inverse of its
-  residual noise rather than stacking samples equally, so a noisier file does not dominate.
-- The identifier reports friction parameter errors against the real model when
-  `--model_real` is given.
 
 ### Simulator
 - Noisy measurements are saved under the `*_raw` keys (matching the excite.py/csv2npz.py

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ humanoid robots. It aims to provide a complete solution for obtaining physical c
 The full floating-base dynamics are identifiable both in simulation and from real robot measurements. All steps
 of the pipeline can be run from the command line or through a graphical interface (`uv run gui.py`).
 
+FloBaRoID was originally developed at the [Advanced Robotics department](https://advr.iit.it/) of the
+Istituto Italiano di Tecnologia (IIT) for the WALK-MAN humanoid robot, and has since been generalized to
+arbitrary floating-base tree-structured robots.
+
 <div>
 <img alt="Overview diagram" src="https://cdn.rawgit.com/kjyv/FloBaRoID/master/documentation/identification_overview.svg" width="62%" align="left" hspace="5px">
 <img alt="WALKMAN suspended from a crane in the visualizer" src="documentation/walkman_suspended.jpg" width="33%">
@@ -34,6 +38,7 @@ Features:
   * essential standard parameters \[Pham1991\]\[Gautier2013\], estimating only those that are most certain for the measurement data and leaving the others unchanged
   * SDP-constrained identification for physically consistent parameters \[Sousa2014\], using cvxpy (using e.g. CLARABEL or MOSEK solvers)
   * closest-to-CAD recovery of standard parameters from feasible base solution, optionally observability-weighted (pull weakly-determined parameters toward CAD, leave well-determined ones free)
+  * geometric (log-det divergence) CAD prior \[Lee2020\]: pull each link's pseudo-inertia toward CAD on the SPD manifold instead of by Euclidean distance, repelling degenerate (zero-mass) solutions (`cadRegularizationMode: geometric`)
   * identification from several measurement files at once, with optional per-trajectory inverse-noise weighting
   * two-step friction identification: friction-free base parameter estimation from base wrench equations \[Ayusawa2014\], followed by per-joint friction fitting from the residual
 * 3D visualization of robot model, trajectories, and world environment (OpenGL)
@@ -121,7 +126,20 @@ Known limitations:
 * YARP excitation module is not very generic (ROS should be)
 * using position control over YARP is not realtime safe and can expose timing issues (especially with python to C bridge)
 
-SDP identification approach based on \[Sousa2014\] and [cdsousa/wam7\_dyn\_ident](https://github.com/cdsousa/wam7_dyn_ident), reimplemented using cvxpy.
+The SDP-constrained identification follows the LMI formulation of \[Sousa2014\] (and the reference
+implementation [cdsousa/wam7\_dyn\_ident](https://github.com/cdsousa/wam7_dyn_ident)), but is a from-scratch
+reimplementation that differs in how the problem is built and solved:
+
+* **Construction.** The original builds the linear matrix inequalities *symbolically* (sympy with `lmi_sdp`).
+  This toolkit instead assembles the constraint matrices *numerically* and hands them to [cvxpy](https://www.cvxpy.org/).
+  Avoiding symbolic expansion makes constraint construction far faster and keeps it tractable for high-DOF
+  floating-base models with hundreds of standard parameters, where symbolic generation becomes prohibitively
+  slow and memory-heavy.
+* **Solver.** The problem is solved through cvxpy's conic-solver abstraction, so any of its modern interior-point
+  solvers can be used (CLARABEL by default, MOSEK and others optional). These are numerically more stable on
+  large, ill-conditioned floating-base problems than the earlier solver pipeline; the solver and its tolerances
+  are configurable (`sdpSolver`, `sdpSolverOptions`), and a failed solve degrades gracefully to the a priori
+  parameters instead of aborting.
 
 Usage is licensed under the LGPL 3.0, see License.md. Please quote the following publication if you're using this software for any project:
 `S. Bethge, J. Malzahn, N. Tsagarakis, D. Caldwell: "FloBaRoID — A Software Package for the Identification of Robot Dynamics Parameters", 26th International Conference on Robotics in Alpe-Adria-Danube Region (RAAD), 2017`
@@ -143,3 +161,5 @@ Usage is licensed under the LGPL 3.0, see License.md. Please quote the following
 \[Ayusawa2014\] K. Ayusawa, G. Venture, Y. Nakamura: "Identifiability and identification of inertial parameters using the underactuated base-link dynamics for legged multibody systems," The International Journal of Robotics Research, vol. 33, no. 3, pp. 446–468, 2014.
 
 \[Ayusawa2017\] K. Ayusawa, A. Rioux, E. Yoshida, G. Venture, M. Gautier: "Generating Persistently Exciting Trajectory Based on Condition Number Optimization," IEEE International Conference on Robotics and Automation (ICRA), Singapore, pp. 6518–6524, 2017.
+
+\[Lee2020\] T. Lee, P. M. Wensing, F. C. Park: "Geometric Robot Dynamic Identification: A Convex Programming Approach," IEEE Transactions on Robotics, vol. 36, no. 2, pp. 348–365, 2020.

--- a/configs/walkman_full.yaml
+++ b/configs/walkman_full.yaml
@@ -429,10 +429,19 @@ useDependents: 0
 #   'observability' — pull every identifiable param with a per-parameter weight that
 #                     grows where the data determines it poorly, so well-determined
 #                     params stay free and weakly-determined ones stay near CAD.
+#   'geometric'     — pull each link's pseudo-inertia toward CAD with the log-det Bregman
+#                     divergence on the SPD manifold (Lee et al. 2020). Coordinate
+#                     invariant and repels degenerate (zero-mass) solutions; strength is
+#                     geometricRegularizationFactor (not regularizationFactor). See
+#                     documentation/geometric_prior_analysis.md.
+# 'uniform'/'observability' overall strength is the internal regularizationFactor.
 # Does not affect the (data-determined) base parameters, only the standard-parameter
-# decomposition within the null space. Overall strength is the internal
-# regularizationFactor.
+# decomposition within the null space.
 cadRegularizationMode: observability
+# geometric-mode tuning (only used when cadRegularizationMode is 'geometric'):
+geometricRegularizationFactor: 1.0   # dimensionless prior strength (residual is normalized)
+geometricObservabilityWeighting: 0   # scale each link's divergence by its observability
+                                     # weight; only helps with heterogeneous per-link CAD trust
 
 # use weighted least squares(WLS) instead of ordinary least squares
 # needs small condition number, otherwise might amplify some parameters too much as the

--- a/configs/walkman_full.yaml
+++ b/configs/walkman_full.yaml
@@ -437,7 +437,9 @@ useDependents: 0
 # 'uniform'/'observability' overall strength is the internal regularizationFactor.
 # Does not affect the (data-determined) base parameters, only the standard-parameter
 # decomposition within the null space.
-cadRegularizationMode: observability
+# 'geometric' measured the best base-parameter distance on this model (see
+# documentation/geometric_prior_analysis.md), so it is the configured choice here.
+cadRegularizationMode: geometric
 # geometric-mode tuning (only used when cadRegularizationMode is 'geometric'):
 geometricRegularizationFactor: 1.0   # dimensionless prior strength (residual is normalized)
 geometricObservabilityWeighting: 0   # scale each link's divergence by its observability

--- a/documentation/geometric_prior_analysis.md
+++ b/documentation/geometric_prior_analysis.md
@@ -1,0 +1,86 @@
+# Geometric (log-det divergence) CAD prior — findings
+
+Analysis of the `cadRegularizationMode: geometric` prior (Lee et al. 2020) against the
+existing `uniform` and `observability` Euclidean CAD pulls. Context and the design
+rationale are in `std_parameter_roadmap.md` section (a). Numbers below are from specific
+runs and are findings, not durable documentation.
+
+## What the prior does
+
+Instead of pulling standard parameters toward CAD with a Euclidean (weighted L2) residual,
+it adds the log-det Bregman divergence between each link's 4×4 pseudo-inertia and its CAD
+value to the SDP objective:
+
+    D(P ‖ P0) = tr(P0^-1 P) − logdet(P) + logdet(P0) − 4
+
+It is coordinate/frame invariant, convex, zero iff `P = P0`, and diverges as a link
+approaches degeneracy — so it repels the zero-mass / flat-inertia solutions the Euclidean
+pull leaves unpenalized.
+
+## Numerical scaling was required to reach the floating-base robot
+
+The naïve implementation solved on small/well-conditioned systems (threeLink, KUKA) but
+**failed on the 29-DOF / 480-param walkman**: CLARABEL returned `solver_error` and SCS
+reported a (false) unbounded ray, falling back to the a priori model. The objective is
+provably bounded below (the divergence is ≥ 0), so this was numerical, not structural. Two
+fixes made it solve:
+
+- **Whitening.** Evaluate the divergence on `Q = P0^{-1/2} P P0^{-1/2}` (≈ I at the a
+  priori) and use `tr(Q) − logdet(Q) − 4`. Mathematically identical (`logdet(P0)` cancels)
+  but O(1)-scaled regardless of each link's CAD conditioning. The raw `tr(P0^-1 P)` form is
+  catastrophic for small links whose CAD pseudo-inertia spans many orders of magnitude:
+  `P0^-1` is then huge and the conic solver cannot equilibrate the resulting dynamic range.
+- **Residual normalization.** The torque-residual block of the objective is ~2.1e7 on
+  walkman while the divergence is O(1); normalizing the residual to O(1) (fit-preserving)
+  makes the two terms commensurate.
+- Pinned links (`dontChangeLinks`) are also skipped — they were adding degenerate
+  (variable-fixed) `log_det` blocks for no benefit (42 → 30 links on walkman).
+
+## Walkman (29 DOF, suspended), CAD = `walkman_apriori`, real = `walkman_measured`
+
+Identification only (no trajectory optimization), `walkman_measured.urdf.measurements.npz`,
+default `geometricRegularizationFactor = 1.0`. Distances are L2 to the real model over the
+identified parameters.
+
+| mode           | std-param distance | base-param distance |
+|----------------|--------------------|---------------------|
+| uniform        | 4.60               | 4.80                |
+| observability  | 3.41               | 2.82                |
+| geometric      | 3.30               | **2.25**            |
+| geometric+obs  | 3.31               | 2.26                |
+
+- The **geometric prior gives the best base-parameter distance** — the meaningful,
+  data-driven metric (the roadmap's primary metric) — beating both Euclidean modes. It also
+  gives the best standard-parameter distance.
+- **Observability-weighting the geometric prior is a no-op here** (2.25 vs 2.26). On a
+  uniformly-perturbed synthetic CAD every link is equally (un)trustworthy, so the per-link
+  observability scaling has nothing to discriminate; whitening already makes each link's
+  divergence scale-invariant. It is expected to matter only when CAD quality genuinely
+  varies between links (a real-robot scenario), the same regime where per-link soft-trust
+  priors pay off.
+
+## KUKA LWR4 (7 DOF, fixed base), real hardware data
+
+No ground-truth model; metric is held-out validation NRMS (train on `measurements_1`,
+validate on `measurements_2`).
+
+| mode           | held-out validation NRMS |
+|----------------|--------------------------|
+| uniform        | 0.211 %                  |
+| observability  | 0.176 %                  |
+| geometric      | 0.181 %                  |
+| geometric+obs  | 0.183 %                  |
+
+On a well-conditioned real robot the regularization choice barely affects torque
+generalization; the geometric prior matches observability and slightly beats uniform, i.e.
+it does not hurt the fit. This is consistent with the roadmap: the prior changes the
+null-space decomposition, not the data-determined torque model.
+
+## Takeaways
+
+- The geometric prior is the better default *metric* for the null-space CAD pull: it
+  improves base-parameter distance on the floating-base robot and does not hurt the fit on
+  the well-conditioned arm.
+- Whitening is mandatory for it to scale; the raw divergence form does not.
+- Observability-weighting it adds nothing on uniformly-perturbed synthetic CAD; revisit it
+  only with heterogeneous per-link CAD trust.

--- a/documentation/std_parameter_roadmap.md
+++ b/documentation/std_parameter_roadmap.md
@@ -46,6 +46,33 @@ Everything below is grouped accordingly.
   barely changes the torque fit or held-out validation; on small/poorly-conditioned
   systems the fit can shift more (it trades a little fit for CAD-closeness), so it is
   opt-in: default `uniform` preserved, enabled for walkman.
+- ✅ **Geometric (log-det divergence) CAD prior** (`cadRegularizationMode: geometric`):
+  pulls each link's 4×4 pseudo-inertia toward its CAD value with the log-det Bregman
+  divergence `D(P‖P₀) = tr(P₀⁻¹P) − logdet(P) + logdet(P₀) − 4` (Lee et al. 2020), added
+  to the SDP objective rather than as Euclidean residual rows. Unlike the
+  uniform/observability Euclidean pull, the divergence is coordinate/frame invariant
+  (it does not mix kg, kg·m, kg·m² in one L2 norm), convex in the inertial parameters,
+  zero iff `P = P₀`, and diverges as a link approaches degeneracy — so it actively repels
+  the zero-mass / flat-inertia null-space solutions the Euclidean pull leaves unpenalized
+  (the robustness failure mode SDP identification is known for). Links with degenerate
+  (non-PD) CAD pseudo-inertia, pinned (`dontChangeLinks`), or in gravity-only mode are
+  skipped. Strength is tuned via `geometricRegularizationFactor`.
+  **Numerically, it must be whitened to scale**: the divergence is evaluated on
+  `Q = P₀^{-1/2} P P₀^{-1/2}` (≈ I at the a priori) as `tr(Q) − logdet(Q) − 4`
+  — mathematically identical but O(1)-scaled regardless of each link's CAD conditioning.
+  The raw `tr(P₀⁻¹P) − logdet(P)` form makes the conic solver fail on a large floating-base
+  robot (small links have CAD pseudo-inertia spanning many orders of magnitude); the
+  torque-residual block is also normalized to O(1) so it is commensurate with the
+  divergence. With `geometricObservabilityWeighting: true` it composes with the
+  observability lever (each link's divergence scaled by the mean observability weight of
+  its 10 params) — but on uniformly-perturbed synthetic CAD this adds nothing (every link
+  is equally untrustworthy), so it is expected to matter only with heterogeneous per-link
+  CAD trust, the same regime as soft-trust priors. It does not recover *more* std params
+  (structural limit, section b) and cannot beat the prior-domination ceiling — it changes
+  *which* consistent null-space point is chosen toward a more physically plausible one.
+  Measured to give the best base-parameter distance among the prior modes on the
+  floating-base robot while not hurting the fit on the well-conditioned arm; see
+  `documentation/geometric_prior_analysis.md`. Opt-in; default `uniform` preserved.
 - ⏸ **Per-link soft-trust priors**: graded per-link trust in CAD (generalizing
   `dontChangeLinks` from hard pin to a finite weight). The only lever to preserve std
   accuracy on links whose CAD is trustworthy. Trust is prior knowledge the data cannot
@@ -159,6 +186,9 @@ extra instrumentation reaches only ~10% of that. So **priors are essentially the
 practical lever** for getting standard parameters closer to real:
 - ✅ observability-weighted CAD regularization (done) — keeps the decomposition sensible
   where the data is weak;
+- ✅ geometric (log-det divergence) CAD prior (done) — a coordinate-invariant prior metric
+  that repels degenerate (zero-mass) null-space solutions and composes with the
+  observability weighting;
 - ⏸ per-link soft-trust priors — the remaining lever, valuable only when CAD quality
   genuinely varies between links (real-robot knowledge).
 

--- a/identification/sdp.py
+++ b/identification/sdp.py
@@ -108,6 +108,9 @@ class SDP:
                 link_params = set(range(i * 10, i * 10 + 10))
                 if link_params.issubset(pinned_params) or link_params.issubset(self.delete_cols):
                     pinned_links.add(i)
+            # exposed for the geometric prior, which must skip links pinned to a priori
+            self.pinned_params = pinned_params
+            self.pinned_links = pinned_links
 
             if idf.opt["identifyGravityParamsOnly"]:
                 # only constrain mass > 0
@@ -289,6 +292,161 @@ class SDP:
         if idf.opt["showTiming"]:
             print(f"Initializing cvxpy constraints took {t.interval:.3f} sec.")
 
+    def _observabilityWeights(self, R1_K: np.ndarray) -> np.ndarray:
+        """Per-parameter CAD-pull weights from a ridge-regularized normal matrix.
+
+        The reduced normal matrix M = (R1*K)^T (R1*K) acts as the (unscaled) parameter
+        covariance: diag((M + eps I)^-1) is small for well-determined params (aligned
+        with large singular directions) and large for poorly-determined ones (incl. the
+        null space, where it tends to 1/eps). The ridge eps makes M invertible and is
+        scaled to M's magnitude so it is unit-invariant; the exact value only sets the
+        spread ceiling, which the clip below caps. Weights are returned ordered like
+        idable_params, normalized so the median is ~1 (keeping overall pull strength
+        comparable to the uniform mode / regularizationFactor) and clipped to [0.1, 100]:
+        well-determined params keep a small (0.1x) pull, the worst-determined a strong
+        (100x) one, avoiding extreme weights from near-zero or near-singular entries.
+        """
+        M = R1_K.T @ R1_K
+        eps = 1e-6 * float(np.trace(M)) / M.shape[0]
+        cov_diag = np.clip(np.diag(la.inv(M + eps * np.eye(M.shape[0]))), 0.0, None)
+        obs_std = np.sqrt(cov_diag)
+        positive = obs_std[obs_std > 0]
+        med = float(np.median(positive)) if positive.size else 1.0
+        return np.clip(obs_std / med, 0.1, 100.0)
+
+    @staticmethod
+    def _pseudoInertiaNumeric(p: np.ndarray) -> np.ndarray:
+        """Build the 4x4 pseudo-inertia matrix from a link's 10 standard parameters.
+
+        The pseudo-inertia is P = [[Sigma, h], [h^T, m]] with first moment h = m*c and
+        Sigma = 0.5*trace(I)*I_3 - I (the density-weighted second moment matrix). P is
+        positive definite iff the link parameters are physically consistent.
+        """
+        m, mx, my, mz, Ixx, Ixy, Ixz, Iyy, Iyz, Izz = (float(v) for v in p)
+        sxx = 0.5 * (-Ixx + Iyy + Izz)
+        syy = 0.5 * (Ixx - Iyy + Izz)
+        szz = 0.5 * (Ixx + Iyy - Izz)
+        return np.array(
+            [
+                [sxx, -Ixy, -Ixz, mx],
+                [-Ixy, syy, -Iyz, my],
+                [-Ixz, -Iyz, szz, mz],
+                [mx, my, mz, m],
+            ]
+        )
+
+    def _pseudoInertiaExpr(self, i: int) -> cp.Expression:
+        """Build the 4x4 pseudo-inertia of link i as an affine cvxpy expression in self.x.
+
+        Mirrors _pseudoInertiaNumeric but over the decision variable, for use in the
+        geometric (log-det divergence) prior.
+        """
+        idx = self.param_index_map
+        m = self.x[idx[i * 10]]
+        mx = self.x[idx[i * 10 + 1]]
+        my = self.x[idx[i * 10 + 2]]
+        mz = self.x[idx[i * 10 + 3]]
+        Ixx = self.x[idx[i * 10 + 4]]
+        Ixy = self.x[idx[i * 10 + 5]]
+        Ixz = self.x[idx[i * 10 + 6]]
+        Iyy = self.x[idx[i * 10 + 7]]
+        Iyz = self.x[idx[i * 10 + 8]]
+        Izz = self.x[idx[i * 10 + 9]]
+        sxx = 0.5 * (-Ixx + Iyy + Izz)
+        syy = 0.5 * (Ixx - Iyy + Izz)
+        szz = 0.5 * (Ixx + Iyy - Izz)
+        return cp.bmat(
+            [
+                [_s(sxx), _s(-Ixy), _s(-Ixz), _s(mx)],
+                [_s(-Ixy), _s(syy), _s(-Iyz), _s(my)],
+                [_s(-Ixz), _s(-Iyz), _s(szz), _s(mz)],
+                [_s(mx), _s(my), _s(mz), _s(m)],
+            ]
+        )
+
+    def _buildGeometricPrior(self, idf: Identification, R1_K: np.ndarray) -> cp.Expression | int:
+        """Build a geometric (log-det Bregman divergence) prior pulling each link's
+        pseudo-inertia toward its CAD value on the SPD manifold (Lee et al., 2020).
+
+        Unlike the Euclidean CAD pull (uniform/observability modes), the divergence
+            D(P || P0) = tr(P0^-1 P) - logdet(P) + logdet(P0) - 4
+        is coordinate/frame invariant, convex in the inertial parameters, zero iff
+        P == P0, and diverges as P approaches a degenerate (e.g. zero-mass) link. It
+        therefore repels the physically implausible null-space solutions a Euclidean
+        pull leaves unpenalized. Added to the objective rather than as residual rows, and
+        evaluated in whitened (affine-invariant) form for numerical stability (see below).
+
+        With `geometricObservabilityWeighting` enabled, each link's divergence is scaled
+        by the mean observability weight of its 10 params (same per-parameter weights as
+        the observability mode), so links the data determines poorly are pulled toward
+        CAD harder and well-determined links stay free.
+
+        Only full links whose 10 params are all free (not pinned/deleted) and whose CAD
+        pseudo-inertia is positive definite get a term; the rest are skipped.
+        """
+        if idf.opt["identifyGravityParamsOnly"]:
+            # inertia params are not identified here, so a full pseudo-inertia is undefined
+            return 0
+
+        pinned_links: set[int] = getattr(self, "pinned_links", set())
+        pinned_params: set[int] = getattr(self, "pinned_params", set())
+        reg_links = [
+            i
+            for i in range(idf.model.num_links)
+            # all 10 params must be free decision variables (not deleted, not pinned to CAD):
+            # a pinned link is already fixed at its CAD value, so its divergence is a
+            # degenerate (constant) log-det block that only burdens the conic solver.
+            if i not in pinned_links
+            and all(p in self.param_index_map and p not in pinned_params for p in range(i * 10, i * 10 + 10))
+        ]
+        if not reg_links:
+            return 0
+
+        # per-link weight. The torque-residual block of the objective is normalized to
+        # O(1) for the geometric mode (see identifyFeasibleStandardParameters), so the
+        # weight is a plain dimensionless strength tuned by `geometricRegularizationFactor`
+        # rather than the base-error-scaled `regularizationFactor` the Euclidean modes use
+        # (mixing the ~1e7 residual with the O(1) divergence breaks the conic solver).
+        base = float(idf.opt.get("geometricRegularizationFactor", 1.0)) / len(reg_links)
+
+        obs_w: np.ndarray | None = None
+        if idf.opt.get("geometricObservabilityWeighting", False):
+            obs_w = self._observabilityWeights(R1_K)
+
+        terms: list[cp.Expression] = []
+        skipped: list[int] = []
+        for i in reg_links:
+            P_cad = self._pseudoInertiaNumeric(idf.model.xStdModel[i * 10 : i * 10 + 10])
+            evals, evecs = la.eigh(P_cad)
+            if float(evals.min()) <= 1e-9:
+                # CAD link is (near-)degenerate: P0^-1/2 undefined, skip it
+                skipped.append(i)
+                continue
+            # Whiten by W = P0^-1/2 so the divergence is evaluated on Q = W P W, which is
+            # ~I at the a priori. This is the affine-invariant form of the divergence and
+            # is mathematically identical (logdet(P0) cancels), but Q is O(1) regardless of
+            # how badly P0 is scaled, which the raw tr(P0^-1 P) - logdet(P) form is not:
+            # small links have P0 spanning many orders of magnitude, giving the conic
+            # solver an unsolvable dynamic range.
+            W = evecs @ np.diag(1.0 / np.sqrt(evals)) @ evecs.T
+            Q = W @ self._pseudoInertiaExpr(i) @ W
+            D = cp.trace(Q) - cp.log_det(Q) - 4
+            link_w = base
+            if obs_w is not None:
+                # aggregate the link's 10 per-param observability weights into one scalar
+                link_w *= float(np.mean([obs_w[self.param_index_map[p]] for p in range(i * 10, i * 10 + 10)]))
+            terms.append(link_w * D)
+
+        if skipped and idf.opt["verbose"]:
+            names = ", ".join(idf.model.linkNames[i] for i in skipped)
+            print(Fore.YELLOW + f"  Geometric prior skipped (non-PD CAD pseudo-inertia): {names}" + Fore.RESET)
+        if not terms:
+            return 0
+        if idf.opt["verbose"]:
+            weighting = "observability-weighted" if obs_w is not None else "uniform"
+            print(f"  Geometric CAD regularization: {len(terms)} links, base weight={base:.4g} ({weighting})")
+        return cp.sum(terms)
+
     def identifyFeasibleStandardParameters(self, idf: Identification) -> None:
         """Find physically consistent standard parameters minimizing torque error."""
         with Timer() as t:
@@ -343,29 +501,15 @@ class SDP:
                     set(idf.model.non_id).difference(self.delete_cols).intersection(idf.model.identified_params)
                 )
                 if reg_mode == "observability":
-                    # Per-parameter spread from a ridge-regularized normal matrix of the
-                    # reduced system (R1*K), which acts as the (unscaled) parameter
-                    # covariance: diag((M + eps I)^-1) is small for well-determined params
-                    # (aligned with large singular directions) and large for poorly-
-                    # determined ones (incl. the null space, where it tends to 1/eps).
-                    M = R1_K.T @ R1_K
-                    # ridge so M is invertible and null-space directions get a large but
-                    # finite spread; scaled to M's magnitude so it is unit-invariant. The
-                    # exact value only sets the spread ceiling, which the clip below caps.
-                    eps = 1e-6 * float(np.trace(M)) / M.shape[0]
-                    cov_diag = np.clip(np.diag(la.inv(M + eps * np.eye(M.shape[0]))), 0.0, None)
-                    obs_std = np.sqrt(cov_diag)  # per-param std, ordered like idable_params
-                    # normalize so the median weight is ~1 (keeps the overall pull strength
-                    # comparable to the uniform mode / regularizationFactor), then clip to
-                    # [0.1, 100]: well-determined params keep a small (0.1x) CAD pull, the
-                    # worst-determined a strong (100x) one, avoiding extreme weights from
-                    # near-zero or near-singular covariance entries.
-                    positive = obs_std[obs_std > 0]
-                    med = float(np.median(positive)) if positive.size else 1.0
-                    w = np.clip(obs_std / med, 0.1, 100.0)
+                    w = self._observabilityWeights(R1_K)
                     reg_params = idable_params
                     base = (float(idf.base_error) / len(reg_params)) * idf.opt["regularizationFactor"]
                     reg_weights = {p: base * float(w[self.param_index_map[p]]) for p in reg_params}
+                elif reg_mode == "geometric":
+                    # geometric prior is a log-det Bregman divergence added to the
+                    # objective (see _buildGeometricPrior), not residual rows, so leave
+                    # reg_params empty here.
+                    pass
                 elif len(p_nid):
                     reg_params = p_nid
                     base = (float(idf.base_error) / len(p_nid)) * idf.opt["regularizationFactor"]
@@ -412,6 +556,21 @@ class SDP:
                             f"  Friction regularization: lambda={lambda_f:.4f}, scaled={l_f:.4f}, {n_friction} params"
                         )
 
+            geo_mode = (
+                idf.opt["useRegressorRegularization"] and idf.opt.get("cadRegularizationMode", "uniform") == "geometric"
+            )
+            if geo_mode:
+                # Normalize the torque-residual block to O(1) so it is commensurate with
+                # the dimensionless log-det divergence added below. The unnormalized
+                # squared residual is ~1e7 on a large robot while the divergence operates
+                # on O(1) inertial quantities (kg, kg*m^2); that ~1e10 dynamic range
+                # cannot be equilibrated by the conic solver (CLARABEL solver_error / SCS
+                # reports a false-unbounded ray). Scaling the residual is fit-preserving
+                # (it only rebalances fit against the prior, which the weight controls).
+                geo_scale = float(np.sqrt(rho2_norm_sqr)) if rho2_norm_sqr > 0 else 1.0
+                e_rho1 = e_rho1 / geo_scale
+                rho2_norm_sqr = rho2_norm_sqr / (geo_scale**2)
+
             if idf.opt["verbose"] > 1:
                 print("Building Schur complement...", time.ctime())
 
@@ -425,8 +584,12 @@ class SDP:
                 ]
             )
 
+            geo_penalty: cp.Expression | int = 0
+            if geo_mode:
+                geo_penalty = self._buildGeometricPrior(idf, R1_K)
+
             all_constraints = [U_rho >> 0] + self.constraints
-            prob = cp.Problem(cp.Minimize(u), all_constraints)
+            prob = cp.Problem(cp.Minimize(u + geo_penalty), all_constraints)
 
             if idf.opt["verbose"]:
                 print(f"Solving SDP with {self.solver_name} ({len(all_constraints)} constraints)...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flobaroid"
-version = "0.9.7"
+version = "0.9.8"
 description = "FLOating BAse RObot dynamical IDentification"
 readme = "README.md"
 license = "LGPL-3.0"

--- a/tests/test_cad_regularization.py
+++ b/tests/test_cad_regularization.py
@@ -32,6 +32,31 @@ def _identify(monkeypatch, mode):
     return idf
 
 
+def test_geometric_mode_runs_and_stays_physical(monkeypatch):
+    """Geometric (log-det Bregman divergence) mode completes, yields a finite and
+    physically-plausible std-param vector, and produces a decomposition differing from
+    the uniform Euclidean pull.
+
+    The geometric prior pulls each link's pseudo-inertia toward CAD on the SPD manifold,
+    so it keeps masses positive and the decomposition close to CAD; like the
+    observability mode it trades a little torque-fit for CAD-closeness on the tiny
+    threeLink, so fit-invariance is not asserted.
+    """
+    idf_u = _identify(monkeypatch, "uniform")
+    idf_g = _identify(monkeypatch, "geometric")
+
+    xstd_u = np.asarray(idf_u.model.xStd, dtype=float)
+    xstd_g = np.asarray(idf_g.model.xStd, dtype=float)
+
+    assert xstd_g.shape == xstd_u.shape
+    assert np.all(np.isfinite(xstd_g))
+    # link masses (every 10th std param) stay positive — the divergence diverges at zero
+    # mass, so it must not produce a degenerate link
+    assert np.all(xstd_g[0 : idf_g.model.num_model_params : 10] > -1e-9)
+    # the mode is actually active: the standard-parameter decomposition differs
+    assert not np.allclose(xstd_g, xstd_u)
+
+
 def test_observability_mode_runs_and_changes_decomposition(monkeypatch):
     """Observability mode completes, yields a finite physically-plausible std-param vector,
     and produces a decomposition that differs from the uniform mode.

--- a/uv.lock
+++ b/uv.lock
@@ -367,7 +367,7 @@ wheels = [
 
 [[package]]
 name = "flobaroid"
-version = "0.9.7"
+version = "0.9.8"
 source = { virtual = "." }
 dependencies = [
     { name = "colorama" },


### PR DESCRIPTION
Adds a third standard-parameter regularization mode, `cadRegularizationMode: geometric`, that pulls each link's pseudo-inertia toward the a priori (CAD) model with the **log-det Bregman divergence on the SPD manifold** ([Lee et al. 2020](https://ieeexplore.ieee.org/document/8922724)) instead of a Euclidean distance.

## Why
The Euclidean CAD pull (`uniform`/`observability`) mixes incompatible units (kg, kg·m, kg·m²) in one L2 norm and leaves degenerate solutions (zero mass, flat inertia) unpenalized — the robustness failure mode SDP identification is known for. The divergence is coordinate/frame invariant, convex, zero iff `P = P₀`, and **diverges as a link approaches degeneracy**, so it actively repels those solutions.

## What
- New `cadRegularizationMode: geometric`, added to the SDP objective (not as residual rows).
- Evaluated in **whitened (affine-invariant) form** `tr(Q) − logdet(Q) − 4` with `Q = P₀^{-1/2} P P₀^{-1/2}` (≈ I at the a priori). Mathematically identical to the raw divergence but O(1)-scaled regardless of each link's CAD conditioning — without this the conic solver fails on large floating-base robots (CLARABEL `solver_error` / SCS false-unbounded from the ~10¹⁰ dynamic range).
- Torque-residual block normalized to O(1) so it stays commensurate with the divergence; pinned (`dontChangeLinks`) and degenerate-CAD links skipped.
- Tunable via `geometricRegularizationFactor`; optional per-link `geometricObservabilityWeighting`.
- Observability-weight computation factored into a shared helper.
- Opt-in; default `uniform` preserved.

## Results
On the 29-DOF walkman (ground-truth model), geometric gives the **best base-parameter distance** (the primary data-driven metric) and the best std distance among the prior modes; on the well-conditioned KUKA arm it matches observability on held-out NRMS (does not hurt the fit). Observability-weighting the geometric prior is a no-op on uniformly-perturbed synthetic CAD (expected — nothing to discriminate). Full numbers in `documentation/geometric_prior_analysis.md`.

## Also in this PR
- Released as **0.9.8**; the standard-parameter identification work (CAD priors + friction) is grouped under it in the changelog.
- README: project origin (IIT Advanced Robotics, WALK-MAN robot) and how the cvxpy SDP reimplementation differs from the original symbolic one (numeric construction vs sympy/lmi_sdp, selectable modern conic solvers, graceful fallback).

## Testing
Full suite passes (61 tests), ruff + mypy clean. New test covers the geometric mode on the threeLink sim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)